### PR TITLE
FIX: add null list to tour seed data

### DIFF
--- a/Models/Database/SeedData.cs
+++ b/Models/Database/SeedData.cs
@@ -40,10 +40,10 @@ namespace TempleTours.Models.Database
                                     hour: iInner,
                                     minute: 00,
                                     second: 00
-                                    )
+                                    ),
+                                Parties = new List<TourParty>()
                             }
-                        )
-                        ;
+                        );
                     }
                 }
 


### PR DESCRIPTION
Bug with how seed data was implemented caused unexpected behavior in the controller. Explicitly setting each Tour to have an empty List of Parties fixes the issue.